### PR TITLE
[TesterA #158, #156, #130] Fix TesterA UG Bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -183,8 +183,8 @@ TrAcker data is saved in the hard disk automatically after any command that chan
 TrAcker data is saved automatically as a JSON file `[JAR file location]/data/addressbook.json`. Advanced users are welcome to update data directly by editing that data file.
 
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
-If your changes to the data file makes its format invalid, AddressBook will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.<br>
-Furthermore, certain edits can cause the AddressBook to behave in unexpected ways (e.g., if a value entered is outside of the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
+If your changes to the data file makes its format invalid, TrAcker will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.<br>
+Furthermore, certain edits can cause the TrAcker  to behave in unexpected ways (e.g., if a value entered is outside of the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
 </div>
 
 --------------------------------------------------------------------------------------------------------------------

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -253,11 +253,13 @@ Examples:
 
 Deletes the Tutorial tag corresponding to the specified tag name. If the specified tag does not exist, no change should happen.
 
+Warning: All persons with the specified Tutorial tag will also have the tag removed.
+
 Format: `tuttag del /t TAG`
 
 Examples:
 
-* `tuttag del /t WED09` deletes WED09 as a valid Tutorial tag.
+* `tuttag del /t WED09` deletes WED09 as a valid Tutorial tag, and removes the WED09 tag from all persons.
 
 ### Listing All Tutorials: `tuttag list`
 

--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -288,7 +288,7 @@ table {
     text-align: center;
   }
   .site-header:before {
-    content: "AB-3";
+    content: "TrAcker";
     font-size: 32px;
   }
 }


### PR DESCRIPTION
Addresses #158 (UG uses "AB-3" instead of TrAcker in the print header),
#156 (tuttag del behaviour not fully documented),
#130 (UG uses "AddressBook" instead of TrAcker under "Editing the data file" section)