### PR TITLE
[Tester A #147] Update duplicate id behaviour in ug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -86,9 +86,14 @@ Format:
 
 * To add a TA,<br>
   `add ta /n NAME /i ID /p PHONE /e EMAIL`
-<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-All persons are saved as either Students or TAs. If the type of the person is not specified, the person will be 
-saved as a Student by default.
+<div markdown="span" class="alert alert-primary">
+
+:bulb: **Notes:**<br>
+
+* All persons are saved as either Students or TAs. If the type of the person is not specified, the person will be
+  saved as a Student by default.
+* Each person's ID is unique, so you cannot add 2 people with the same ID.
+
 </div>
 
 Examples:


### PR DESCRIPTION
Addresses #147 

Tester A may have mistaken this for a functionality bug when trying to add 2 persons with the same ID. I have updated the description for "add" command in the UG to make it clear that IDs are unique.

For future implementations it might be better to have a more specific error message, as the current error message, "This person already exists in the address book" is not be clear enough.