### PR TITLE
Bugfix

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditTutTagListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTutTagListCommand.java
@@ -93,7 +93,7 @@ public class EditTutTagListCommand extends Command {
             for (Person person : entireList) {
                 Set<Tag> currTags = new HashSet<>(person.getTags());
                 assert person != null;
-                Person editedPerson = createEditedPerson(person, Tag.removeTagFromTagSet(currTags, this.tagName));
+                Person editedPerson = createEditedPerson(person, Tag.removeTutTagFromTagSet(currTags, this.tagName));
 
                 // Update the person list
                 model.setPerson(person, editedPerson);

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -174,6 +174,18 @@ public abstract class Tag {
     }
 
     /**
+     * @param currTags current tag set to be updated.
+     * @param tagName  name of the new tutorial tag.
+     * @return
+     */
+    public static Set<Tag> removeTutTagFromTagSet(Set<Tag> currTags, String tagName) {
+        // remove the potentially existing Tag of the same name from the hashset.
+        Tag newTag = Tag.createTag(tagName, TagStatus.DEFAULT_STATUS);
+        currTags.removeIf(tag -> tag.isTutorial() && tag.equals(newTag));
+        return currTags;
+    }
+
+    /**
      * Removes the tags with the specified tag names from the current set of tags.
      * @param currTags
      * @param tagNames


### PR DESCRIPTION
To fix the bug where tuttag delete TAG1 removes TAG1 of other tag type from persons as well, when the correct behaviour should be that only the tutorial tag of name TAG1 but not tags of the same name but other types should be removed